### PR TITLE
Packet types

### DIFF
--- a/src/rcDeviceProtocol.cpp
+++ b/src/rcDeviceProtocol.cpp
@@ -239,8 +239,6 @@ int8_t DeviceProtocol::update(uint16_t channels[], uint8_t telemetry[]) {
 
     //Covert packet to channels
 
-    //TODO somethings going on with this.
-
     //Check if the packet is a channel packet
     if((packet[0] & 0xF0) == _PACKET_CHANNELS) {
 

--- a/src/rcDeviceProtocol.cpp
+++ b/src/rcDeviceProtocol.cpp
@@ -237,30 +237,28 @@ int8_t DeviceProtocol::update(uint16_t channels[], uint8_t telemetry[]) {
   //read through each transmission we have gotten since the last update
   while(packetStatus == 1) {
 
+    //Covert packet to channels
 
-    //if the a packet was received
-    if(packetStatus == 1) {
+    //TODO somethings going on with this.
 
-      //Covert packet to channels
-
-      //Check if the packet is a channel packet
-      if((packet[0] & 0xF0) == _PACKET_CHANNELS) {
-
-        for(uint8_t i = 0; i < _settings.getNumChannels(); i++) {
-          channels[i] = ((packet[i * 2 + 1] << 8) & 0xFF00) | (packet[i * 2 + 2] &
-                        0x00FF);
-        }
-
-      }
+    //Check if the packet is a channel packet
+    if((packet[0] & 0xF0) == _PACKET_CHANNELS) {
 
       status = 1;
-    } else if(packetStatus < 0) {
-      status = packetStatus;
+
+      for(uint8_t i = 0; i < _settings.getNumChannels(); i++) {
+        channels[i] = ((packet[i * 2 + 1] << 8)) | (packet[i * 2 + 2]);
+      }
+
     }
 
     //Load a transmission.
     packetStatus = check_packet(packet,
                                 _settings.getPayloadSize() * sizeof(uint8_t));
+  }
+
+  if(packetStatus < 0) {
+    status = packetStatus;
   }
 
   return status;

--- a/src/rcGlobal.h
+++ b/src/rcGlobal.h
@@ -57,6 +57,8 @@ protected:
   const uint8_t _NACK = 0x15;
   const uint8_t _TEST = 0x02;
 
+  const uint8_t _PACKET_CHANNELS = 0xA0;
+
   RCSettings _settings;
   RCSettings _pairSettings;
 

--- a/src/rcGlobal.h
+++ b/src/rcGlobal.h
@@ -52,12 +52,15 @@ protected:
 
   RCGlobal();
 
-  const uint8_t _PAIR_ADDRESS[5] = {'P', 'a', 'i', 'r', '0'};
+  const uint8_t _PAIR_ADDRESS[5] = {'P', 'a', 'i', 'r', '0'};//Pair0: 0x50 61 69 72 30
   const uint8_t _ACK = 0x06;
   const uint8_t _NACK = 0x15;
   const uint8_t _TEST = 0x02;
 
   const uint8_t _PACKET_CHANNELS = 0xA0;
+  const uint8_t _PACKET_UPDATE_TRANS_SETTINGS = 0xB1;//TODO: Implement
+  const uint8_t _PACKET_UPDATE_RECVR_SETTINGS = 0xB2;//TODO: Implement
+  const uint8_t _PACKET_DISCONNECT = 0xC0;//TODO: Implement
 
   RCSettings _settings;
   RCSettings _pairSettings;

--- a/src/rcRemoteProtocol.cpp
+++ b/src/rcRemoteProtocol.cpp
@@ -238,7 +238,7 @@ int8_t RemoteProtocol::update(uint16_t channels[], uint8_t telemetry[]) {
 
   //Send the packet.
   int8_t status = send_packet(packet,
-                              sizeof(uint8_t) * _settings.getNumChannels(),
+                              sizeof(uint8_t) * _settings.getPayloadSize(),
                               telemetry, sizeof(uint8_t) * _settings.getPayloadSize());
 
 

--- a/src/rcRemoteProtocol.cpp
+++ b/src/rcRemoteProtocol.cpp
@@ -222,15 +222,17 @@ int8_t RemoteProtocol::update(uint16_t channels[], uint8_t telemetry[]) {
 
   uint8_t packet[_settings.getPayloadSize()];
 
-  //Set the Packet type
   uint8_t i = 0;
 
+  //Set the Packet type
   packet[i++] = _PACKET_CHANNELS + 0;
+  //Set the payload data
   for(; i < min(_settings.getPayloadSize(), _settings.getNumChannels() * 2 + 1);
       i += 2) {
     packet[i] = (channels[(i - 1) / 2] >> 8) & 0x00FF;
     packet[i + 1] = channels[(i - 1) / 2] & 0x00FF;
   }
+  //Set the rest of the packet to 0.
   for(; i < _settings.getPayloadSize(); i++) {
     packet[i] = 0;
   }
@@ -242,7 +244,7 @@ int8_t RemoteProtocol::update(uint16_t channels[], uint8_t telemetry[]) {
                               telemetry, sizeof(uint8_t) * _settings.getPayloadSize());
 
 
-  //Check if the frequency delay has already passed.
+  //If the tick was too long, and there are no errors, set the return to Tick To Short
   if(millis() - _timer > _timerDelay && status >= 0) {
     status = RC_INFO_TICK_TOO_SHORT;
   }

--- a/src/rcRemoteProtocol.cpp
+++ b/src/rcRemoteProtocol.cpp
@@ -216,16 +216,29 @@ int8_t RemoteProtocol::send_packet(void* data, uint8_t dataSize,
 
 int8_t RemoteProtocol::update(uint16_t channels[], uint8_t telemetry[]) {
 
-  //const uint8_t PACKET_BEGIN = 1;
-
-
   if(!isConnected()) {
     return RC_ERROR_NOT_CONNECTED;
   }
 
+  uint8_t packet[_settings.getPayloadSize()];
+
+  //Set the Packet type
+  uint8_t i = 0;
+
+  packet[i++] = _PACKET_CHANNELS + 0;
+  for(; i < min(_settings.getPayloadSize(), _settings.getNumChannels() * 2 + 1);
+      i += 2) {
+    packet[i] = (channels[(i - 1) / 2] >> 8) & 0x00FF;
+    packet[i + 1] = channels[(i - 1) / 2] & 0x00FF;
+  }
+  for(; i < _settings.getPayloadSize(); i++) {
+    packet[i] = 0;
+  }
+
+
   //Send the packet.
-  int8_t status = send_packet(channels,
-                              sizeof(uint16_t) * _settings.getNumChannels(),
+  int8_t status = send_packet(packet,
+                              sizeof(uint8_t) * _settings.getNumChannels(),
                               telemetry, sizeof(uint8_t) * _settings.getPayloadSize());
 
 


### PR DESCRIPTION
Allocate the first byte of each packet to declaring the type of packet.

This allows the ability to send many packets with different meanings.

There is currently only one implemented packet type, but 2 more are planned

* Channels: send channel data
* Update Settings: Update the settings on the receiver
* Disconnect: Disconnect from the receiver.